### PR TITLE
Fix `debuggerReadySignature` check when using a path for `runtimeExecutable`

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -252,7 +252,7 @@ class ProbeRSDebugAdapterServerDescriptorFactory implements vscode.DebugAdapterD
 			);
 
 			// Capture stdout and stderr to ensure RUST_LOG can be redirected
-			debuggerReadySignature = command.concat(" CONSOLE: Listening for requests on port ", debugServer[1]);
+			debuggerReadySignature = "CONSOLE: Listening for requests on port " + debugServer[1];
 			launchedDebugAdapter.stdout?.on('data', (data: string) => {
 				if (data.includes(debuggerReadySignature)) {
 					debuggerReady = true;


### PR DESCRIPTION
When using a path for `runtimeExecutable`, the check for  `debuggerReadySignature` is always failing since `command` will be the full path to the executable, but the program will only print the executable file name.