### PR TITLE
Catch `probe-rs-debugger` panic AND unexpected exits

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "probe-rs-debugger",
   "displayName": "Debugger for probe-rs",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "publisher": "probe-rs",
   "description": "probe-rs Debug Adapter for VS Code.",
   "author": {


### PR DESCRIPTION
Previously a `probe-rs-debugger` panic would fail silently, and the VSCode user would have no hint as to what went wrong.

With this PR, the user will be shown an error message that includes the `stderr` from the `probe-rs-debugger` process. In most cases, this will point to a bug, but it may also be an issue in the environment of the user. Either way, I would not expect most users to be able to resolve this kind of error without logging an issue.

This PR also updates the extension version number to `0.3.2` and will require a new release binary.