### PR TITLE
Fix #15: debugging session closes silently

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
 			"request": "launch",
 			"args": [
 				"--extensionDevelopmentPath=${workspaceFolder}",
-				"${workspaceFolder}/debug_example"
+				"/Users/jacknoppe/dev/microrust-start"
 			],
 			"outFiles": [
 				"${workspaceFolder}/dist/ext/**/*.js"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
 			"request": "launch",
 			"args": [
 				"--extensionDevelopmentPath=${workspaceFolder}",
-				"/Users/jacknoppe/dev/microrust-start"
+				"${workspaceFolder}/debug_example"
 			],
 			"outFiles": [
 				"${workspaceFolder}/dist/ext/**/*.js"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "probe-rs-debugger",
   "displayName": "Debugger for probe-rs",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "publisher": "probe-rs",
   "description": "probe-rs Debug Adapter for VS Code.",
   "author": {
@@ -13,7 +13,7 @@
     "probe-rs embedded debug"
   ],
   "engines": {
-    "vscode": "^1.61.0"
+    "vscode": "^1.62.2"
   },
   "icon": "images/probe-rs-debugger.png",
   "categories": [
@@ -54,17 +54,17 @@
     "@types/mocha": "^9.0.0",
     "@types/node": "^16.11.3",
     "@types/vscode": "^1.61.0",
-    "@typescript-eslint/eslint-plugin": "^5.1.0",
-    "@typescript-eslint/parser": "^5.1.0",
+    "@typescript-eslint/eslint-plugin": "^5.4.0",
+    "@typescript-eslint/parser": "^5.4.0",
     "eslint": "^8.0.1",
     "glob": "^7.2.0",
     "mocha": "^9.1.3",
     "portfinder": "^1.0.28",
     "ts-loader": "^9.2.6",
     "typescript": "^4.4.4",
-    "vsce": "^1.100.2",
+    "vsce": "^2.3.0",
     "vscode-debugadapter-testsupport": "^1.49.0",
-    "webpack": "^5.59.1",
+    "webpack": "^5.64.1",
     "webpack-cli": "^4.9.1"
   },
   "main": "./dist/ext/extension.js",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -174,11 +174,13 @@ class ProbeRSDebugAdapterServerDescriptorFactory implements vscode.DebugAdapterD
 		}
 	}
 
+	// Note. We do NOT use `DebugAdapterExecutable`, but instead use `DebugAdapterServer` in all cases. 
+	// - The decision was made during investigation of an [issue](https://github.com/probe-rs/probe-rs/issues/703) ... basically, after the probe-rs API was fixed, the code would work well for TCP connections (`DebugAdapterServer`), but would not work for STDIO connections (`DebugAdapterServer`). After some searches I found other extension developers that also found the TCP based connections to be more stable.
+	//  - Since then, we have taken advantage of the access to stderr that `DebugAdapterServer` offers to route `RUST_LOG` output from the debugger to the user's VSCode Debug Console. This is a very useful capability, and cannot easily be implemented in `DebugAdapterExecutable`, because it does not allow access to `stderr` [See ongoing issue in VScode repo](https://github.com/microsoft/vscode/issues/108145).
 	async createDebugAdapterDescriptor(session: vscode.DebugSession, executable: vscode.DebugAdapterExecutable | undefined): Promise<vscode.DebugAdapterDescriptor | null | undefined> {
 		probeRsLogLevel = session.configuration.consoleLogLevel;
 
 		// Initiate either the 'attach' or 'launch' request.
-		// We do NOT use DebugAdapterExecutable
 		logToConsole("INFO: Session: " + JSON.stringify(session, null, 2));
 
 		// When starting the debugger process, we have to wait for debuggerStatus to be set to `DebuggerStatus.running` before we continue

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,13 +19,13 @@ export async function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(
 		vscode.debug.registerDebugAdapterDescriptorFactory('probe-rs-debug', descriptorFactory),
 		vscode.debug.onDidReceiveDebugSessionCustomEvent(descriptorFactory.receivedCustomEvent.bind(descriptorFactory)),
+		vscode.debug.onDidTerminateDebugSession(descriptorFactory.dispose.bind(descriptorFactory)),
 	);
 
 	// I cannot find a way to programmatically test for when VSCode is debugging the extension, versus when a user is using the extension to debug their own code, but the following code is usefull in the former situation, so I will leave it here to be commented out by extension developers when needed.
 	// const trackerFactory = new ProbeRsDebugAdapterTrackerFactory();
 	// context.subscriptions.push(
 	// 	vscode.debug.registerDebugAdapterTrackerFactory('probe-rs-debug', trackerFactory),
-	// 	vscode.debug.onDidTerminateDebugSession(descriptorFactory.dispose.bind(descriptorFactory)),
 	// );
 
 }
@@ -300,15 +300,15 @@ class ProbeRSDebugAdapterServerDescriptorFactory implements vscode.DebugAdapterD
 			if (debuggerStatus === (DebuggerStatus.running as DebuggerStatus)) {
 				await new Promise<void>((resolve) => setTimeout(resolve, 500)); // Wait for a fraction of a second more, to allow TCP/IP port to initialize in probe-rs-debugger
 			}
-
-
-			// make VS Code connect to debug server
-			if (debuggerStatus === (DebuggerStatus.running as DebuggerStatus)) {
-				return new vscode.DebugAdapterServer(+debugServer[1], debugServer[0]);
-			} else {
-				return undefined;
-			}
 		}
+
+		// make VS Code connect to debug server
+		if (debuggerStatus === (DebuggerStatus.running as DebuggerStatus)) {
+			return new vscode.DebugAdapterServer(+debugServer[1], debugServer[0]);
+		} else {
+			return undefined;
+		}
+
 	}
 
 	dispose() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -332,19 +332,19 @@ class ProbeRsDebugAdapterTrackerFactory implements DebugAdapterTrackerFactory {
 class ProbeRsDebugAdapterTracker implements DebugAdapterTracker {
 
 	onWillReceiveMessage(message: any) {
-		if (probeRsLogLevel === 'Debug') {
+		if (probeRsLogLevel === 'Debug' || probeRsLogLevel === 'Trace') {
 			logToConsole("DEBUG: Sending message to debug adapter:\n" + JSON.stringify(message, null, 2));
 		}
 	}
 
 	onDidSendMessage(message: any) {
-		if (probeRsLogLevel === 'Debug') {
+		if (probeRsLogLevel === 'Debug' || probeRsLogLevel === 'Trace') {
 			logToConsole("DEBUG: Received message from debug adapter:\n" + JSON.stringify(message, null, 2));
 		}
 	}
 
 	onError(error: Error) {
-		if (probeRsLogLevel === 'Debug') {
+		if (probeRsLogLevel === 'Debug' || probeRsLogLevel === 'Trace') {
 			logToConsole("ERROR: Error in communication with debug adapter:\n" + JSON.stringify(error, null, 2));
 		}
 	}


### PR DESCRIPTION
This fix for #15 includes the following:
- In addition to checking for error `code`, also check for the possibility of a process `signal`. 
- Previously the `probe-rs-debugger` process was started with `child_process.execFile`, which has a default `maxBuffer` for stdio of `1024 * 1024`. When the stdout or stderr (RUST_LOG output is handled this way) exceeded this, VSCode would terminate the process and truncate the output ... and because we didn't test the `signal`, we never saw the `SIGTERM` event happening, and it looked as if the `probe-rs-debugger` failed silently.   I have changed this to use `child_process.spawn`, which uses `Stream` objects instead of `Buffer` objects to handle the stdio from the child process. 
- Bump the version number of the extension to 0.3.3