### PR TITLE
Remove CLI mode from probe-rs-debugger

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "probe-rs-debugger",
   "displayName": "Debugger for probe-rs",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "publisher": "probe-rs",
   "description": "probe-rs Debug Adapter for VS Code.",
   "author": {
@@ -13,7 +13,7 @@
     "probe-rs embedded debug"
   ],
   "engines": {
-    "vscode": "^1.64.2"
+    "vscode": "^1.65.0"
   },
   "icon": "images/probe-rs-debugger.png",
   "categories": [
@@ -53,7 +53,7 @@
     "@types/glob": "^7.2.0",
     "@types/mocha": "^9.1.0",
     "@types/node": "^17.0.21",
-    "@types/vscode": "^1.64.0",
+    "@types/vscode": "^1.65.0",
     "@typescript-eslint/eslint-plugin": "^5.13.0",
     "@typescript-eslint/parser": "^5.13.0",
     "@vscode/debugprotocol": "^1.54.0",
@@ -61,10 +61,10 @@
     "glob": "^7.2.0",
     "mocha": "^9.2.1",
     "portfinder": "^1.0.28",
-    "ts-loader": "^9.2.6",
-    "typescript": "^4.5.5",
+    "ts-loader": "^9.2.7",
+    "typescript": "^4.6.2",
     "vsce": "^2.6.5",
-    "webpack": "^5.69.1",
+    "webpack": "^5.70.0",
     "webpack-cli": "^4.9.2"
   },
   "main": "./dist/ext/extension.js",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -108,13 +108,13 @@ class ProbeRSDebugAdapterServerDescriptorFactory implements vscode.DebugAdapterD
 					onDidWrite: channelWriteEmitter.event,
 					open: () => {
 						let windowIsOpen = true;
-						session.customRequest("rtt_window_opened", { channelNumber, windowIsOpen }).then((response) => {
+						session.customRequest("rttWindowOpened", { channelNumber, windowIsOpen }).then((response) => {
 							logToConsole("DEBUG: probe-rs: RTT Window opened, and ready to receive RTT data on channel" + JSON.stringify(channelNumber, null, 2));
 						});
 					},
 					close: () => {
 						let windowIsOpen = false;
-						session.customRequest("rtt_window_opened", { channelNumber, windowIsOpen }).then((response) => {
+						session.customRequest("rttWindowOpened", { channelNumber, windowIsOpen }).then((response) => {
 							logToConsole("DEBUG: probe-rs: RTT Window closed, and can no longer receive RTT data on channel" + JSON.stringify(channelNumber, null, 2));
 						});
 					},
@@ -126,7 +126,7 @@ class ProbeRSDebugAdapterServerDescriptorFactory implements vscode.DebugAdapterD
 						channelTerminal = reuseTerminal;
 						channelTerminalConfig = channelTerminal.creationOptions as vscode.ExtensionTerminalOptions;
 						let windowIsOpen = true;
-						session.customRequest("rtt_window_opened", { channelNumber, windowIsOpen }).then((response) => {
+						session.customRequest("rttWindowOpened", { channelNumber, windowIsOpen }).then((response) => {
 							logToConsole("DEBUG: probe-rs: RTT Window reused, and ready to receive RTT data on channel" + JSON.stringify(channelNumber, null, 2));
 						});
 						break;
@@ -165,7 +165,7 @@ class ProbeRSDebugAdapterServerDescriptorFactory implements vscode.DebugAdapterD
 				for (var [channelNumber, dataFormat, , channelWriteEmitter] of this.rttTerminals) {
 					if (channelNumber === incomingChannelNumber) {
 						switch (dataFormat) {
-							case 'BinaryLE': //Don't mess with this data
+							case 'BinaryLE': //Don't mess with or filter this data
 								channelWriteEmitter.fire(customEvent.body?.data);
 								break;
 							default: //Replace newline characters with platform appropriate newline/carriage-return combinations
@@ -242,7 +242,6 @@ class ProbeRSDebugAdapterServerDescriptorFactory implements vscode.DebugAdapterD
 			} else {
 				args = [
 					'debug',
-					'--dap'
 				];
 			}
 			args.push("--port");


### PR DESCRIPTION
There are two linked PR's that depend on each other:
- [probe-rs/probe-rs](https://github.com/probe-rs/probe-rs/pull/1041)
- [probe-rs/vscode](https://github.com/probe-rs/vscode/pull/30)
  - A WIP release is available for testing at [probe-rs-debugger-0.3.6.vsix](https://github.com/probe-rs/vscode/releases/download/v0.3.6/probe-rs-debugger-0.3.6.vsix)

Henceforth, the `probe-rs-debugger` command will only accept four CLI commands:
```
USAGE:
    probe-rs-debugger <SUBCOMMAND>

OPTIONS:
    -h, --help       Print help information
    -V, --version    Print version information

SUBCOMMANDS:
    debug         Open target in debug mode and accept debug commands. This only works as a
                      [protocol::DapAdapter] and uses DAP Protocol debug commands (enables
                      connections from clients such as Microsoft Visual Studio Code)
    help          Print this message or the help of the given subcommand(s)
    list          List all connected debug probes
    list-chips    List all probe-rs supported chips
```
