### PR TITLE
Changes to match probe-rs-debugger 0.14.0

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -1,8 +1,0 @@
-required_approvals = 1
-block_labels = ["wip"]
-delete_merged_branches = true
-status = [
-    "Build (ubuntu-latest)",
-    "Build (macos-latest)",
-    "Build (windows-latest)",
-]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
-
-## 0.3 An updated 'Alpha' release that redefines how 'launch' versus 'attach' behaviour works.
+## 0.4.2 An updated 'Alpha' release to update dependencies, and improve logging and stability.
 - The majority of functionality is implemented in the [probe-rs-debugger](https://github.com/probe-rs/probe-rs/tree/master/debugger). Please refer to the [probe-rs CHANGELOG](https://github.com/probe-rs/probe-rs/blob/master/CHANGELOG.md) for detailed innformation on changes that affect functionality in this extension.
 
+## 0.3 An updated 'Alpha' release that redefines how 'launch' versus 'attach' behaviour works.
 
 ## 0.2.2 An updated 'Alpha' release with up to date DAP protocol support, and integration with [probe-rs](https://github.com/probe-rs/probe-rs). 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "probe-rs-debugger",
     "displayName": "Debugger for probe-rs",
-    "version": "0.4.1",
+    "version": "0.4.2",
     "publisher": "probe-rs",
     "description": "probe-rs Debug Adapter for VS Code.",
     "author": {
@@ -47,20 +47,20 @@
     "dependencies": {
         "@vscode/debugadapter": "^1.58.0",
         "await-notify": "1.0.1",
-        "portfinder": "^1.0.32"
+        "get-port": "^6.1.2"
     },
     "devDependencies": {
         "@types/glob": "^8.0.0",
         "@types/mocha": "^10.0.1",
-        "@types/node": "^18.11.15",
+        "@types/node": "^18.11.18",
         "@types/vscode": "^1.74.0",
-        "@typescript-eslint/eslint-plugin": "^5.46.1",
-        "@typescript-eslint/parser": "^5.46.1",
+        "@typescript-eslint/eslint-plugin": "^5.48.1",
+        "@typescript-eslint/parser": "^5.48.1",
         "@vscode/debugprotocol": "^1.58.0",
-        "eslint": "^8.29.0",
+        "eslint": "^8.31.0",
+        "get-port": "^6.1.2",
         "glob": "^8.0.3",
         "mocha": "^10.2.0",
-        "portfinder": "^1.0.32",
         "prettier": "^2.8.1",
         "ts-loader": "^9.4.2",
         "typescript": "^4.9.4",


### PR DESCRIPTION
VSCode no longer checks a `stderr` signature when it waits for `probe-rs-debugger` to startup, but tests against the availability of the TCP port number instead.

Also bumps dependencies and own version number to 0.4.2