### PR TITLE
Improve error message when debug adapter executable is not found

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,7 +11,5 @@
     // Enable prettier format on save
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true,
-    "editor.formatOnPaste": false,
-    "nrf-connect.topdir": "${nrf-connect.sdk:2.2.0}",
-    "nrf-connect.toolchain.path": "${nrf-connect.toolchain:2.2.0}"
+    "editor.formatOnPaste": false
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,5 +11,7 @@
     // Enable prettier format on save
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true,
-    "editor.formatOnPaste": false
+    "editor.formatOnPaste": false,
+    "nrf-connect.topdir": "${nrf-connect.sdk:2.2.0}",
+    "nrf-connect.toolchain.path": "${nrf-connect.toolchain:2.2.0}"
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -385,7 +385,7 @@ class ProbeRSDebugAdapterServerDescriptorFactory implements vscode.DebugAdapterD
             logToConsole(
                 `${ConsoleLogSources.console.toLowerCase()}: Launching new server ${JSON.stringify(
                     command,
-                )} ${JSON.stringify(args)}}`,
+                )} ${JSON.stringify(args)}} ${JSON.stringify(options)}`,
             );
 
             try {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -385,7 +385,7 @@ class ProbeRSDebugAdapterServerDescriptorFactory implements vscode.DebugAdapterD
             logToConsole(
                 `${ConsoleLogSources.console.toLowerCase()}: Launching new server ${JSON.stringify(
                     command,
-                )} ${JSON.stringify(args)}} ${JSON.stringify(options)}`,
+                )} ${JSON.stringify(args)} ${JSON.stringify(options)}`,
             );
 
             try {


### PR DESCRIPTION
New error message after this PR:

<img width="559" alt="grafik" src="https://user-images.githubusercontent.com/859555/218254769-755b81eb-e666-4d9b-9ea5-521951dcae7b.png">


Before:

<img width="559" alt="grafik" src="https://user-images.githubusercontent.com/859555/218254856-a18ead41-172b-4c22-98aa-b877bef98c9a.png">

It also seems that the code which tries to check open ports doesn't really work, since it failed to detect that the server didn't start at all.

