### PR TITLE
Readme and Package changes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,8 +11,9 @@ on:
 
 jobs:
   publish:
-    name: Publish the VS Code Extension
-    if: success() && startsWith(github.ref, 'refs/tags/') && matrix.os == 'ubuntu-latest'
+    run-name: Publish the VS Code Extension
+    runs-on: ubuntu-latest
+    if: success() && startsWith(github.ref, 'refs/tags/') && runner.name == 'ubuntu-latest'
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Documentation
 
-Full documentation on [Installation](https://probe.rs/docs/tools/vscode/#installation), Configuration and supported functionality
+Full documentation on [Installation](https://probe.rs/docs/tools/vscode/#installation), [Configuration](https://probe.rs/docs/tools/vscode/#usage-and-configuration) and [supported functionality](https://probe.rs/docs/tools/vscode/#current-working-functionality-and-known-limitations)
 can be found at [the probe-rs webpage](https://probe.rs/docs/tools/vscode/) and
 under the [visual tour
 heading](https://probe.rs/docs/tools/vscode/#a-visual-guide-of-implemented-features)

--- a/README_PUBLISH.md
+++ b/README_PUBLISH.md
@@ -1,0 +1,12 @@
+# VS Code probe-rs-debugger
+
+A VS Code extension for debugging embedded Rust applications using probe-rs, with support for a large range of debug probes and chips, including many variants of ARM Cortex-M, ARM Cortex-A, and RISC-V.
+
+## Documentation
+
+Full documentation on [Installation](https://probe.rs/docs/tools/vscode/#installation), [Configuration](https://probe.rs/docs/tools/vscode/#usage-and-configuration) and [supported functionality](https://probe.rs/docs/tools/vscode/#current-working-functionality-and-known-limitations)
+can be found at [the probe-rs webpage](https://probe.rs/docs/tools/vscode/) and
+under the [visual tour
+heading](https://probe.rs/docs/tools/vscode/#a-visual-guide-of-implemented-features)
+
+<img style="margin-top: 1em; margin-bottom: 1em; max-width:100%; max-height:100%; width: auto; height: auto;" src="https://probe.rs/img/vscode/probe-rs-debugger.gif" />

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
         "embedded",
         "debug",
         "Arm",
-        "Arm Cortex-M",
-        "Arm Cortex-A",
+        "ARM Cortex-M",
+        "ARM Cortex-A",
         "Riscv-v",
         "RTT",
         "SVD"

--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
     "name": "probe-rs-debugger",
     "displayName": "Debugger for probe-rs",
-    "version": "0.17.0",
+    "version": "0.17.1",
     "publisher": "probe-rs",
     "description": "probe-rs Debug Adapter for VS Code.",
     "author": {
         "name": "Jack Noppé",
         "email": "noppej@hotmail.com"
     },
+    "readme": "README_publish.md",
     "license": "(MIT OR Apache-2.0)",
     "pricing": "Free",
     "keywords": [
@@ -16,6 +17,8 @@
         "embedded",
         "debug",
         "Arm",
+        "Arm Cortex-M",
+        "Arm Cortex-A",
         "Riscv-v",
         "RTT",
         "SVD"


### PR DESCRIPTION
The `README.md` will be the default landing page for the GitHub repo.
The `README_PUBLISH.md` is a reduced and user focused version to be the default landing page for the VS Extenstion Marketplace.