### PR TITLE
Support configurable debugger executable

### DIFF
--- a/package.json
+++ b/package.json
@@ -493,6 +493,18 @@
                     }
                 ]
             }
+        ],
+        "configuration": [
+            {
+                "title": "probe-rs Debugger",
+                "properties": {
+                    "probe-rs-debugger.debuggerExecutable": {
+                        "type": "string",
+                        "markdownDescription": "Path to the `probe-rs-debugger` executable. If this is not set, the extension requires that `probe-rs-debugger` (or `probe-rs-debugger.exe`) is available on the system `PATH`.\n\nNote: Settings in 'launch.json' take precedence over this setting.",
+                        "scope": "machine-overridable"
+                    }
+                }
+            }
         ]
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -366,13 +366,7 @@ class ProbeRSDebugAdapterServerDescriptorFactory implements vscode.DebugAdapterD
                 if (session.configuration.hasOwnProperty('runtimeExecutable')) {
                     command = session.configuration.runtimeExecutable;
                 } else {
-                    switch (os.platform()) {
-                        case 'win32':
-                            command = 'probe-rs-debugger.exe';
-                            break;
-                        default:
-                            command = 'probe-rs-debugger';
-                    }
+                    command = debuggerExecutablePath();
                 }
             } else {
                 command = executable.command;
@@ -510,6 +504,27 @@ function startDebugServer(
         });
         launchedDebugAdapter.on('error', errorListener);
     });
+}
+
+// Get the name of the debugger executable
+//
+// This takes the value from configuration, if set, or
+// falls back to the default name.
+function debuggerExecutablePath(): string {
+    let configuration = vscode.workspace.getConfiguration('probe-rs-debugger');
+
+    let configuredPath: string = configuration.get('debuggerExecutable') ?? defaultExecutable();
+
+    return configuredPath;
+}
+
+function defaultExecutable(): string {
+    switch (os.platform()) {
+        case 'win32':
+            return 'probe-rs-debugger.exe';
+        default:
+            return 'probe-rs-debugger';
+    }
 }
 
 // @ts-ignore


### PR DESCRIPTION
Especially for testing, but maybe also for to other reasons,
it's nice to have a setting to specify the debugger executable per machine.
