### PR TITLE
Fix debuggerExecutable is invalid and fails to launch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "probe-rs-debugger",
     "displayName": "Debugger for probe-rs",
-    "version": "0.17.3",
+    "version": "0.17.4",
     "publisher": "probe-rs",
     "description": "probe-rs Debug Adapter for VS Code.",
     "author": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -513,7 +513,7 @@ function startDebugServer(
 function debuggerExecutablePath(): string {
     let configuration = vscode.workspace.getConfiguration('probe-rs-debugger');
 
-    let configuredPath: string = configuration.get('debuggerExecutable') ?? defaultExecutable();
+    let configuredPath: string = configuration.get('debuggerExecutable') || defaultExecutable();
 
     return configuredPath;
 }


### PR DESCRIPTION
The configuration value returned as '' and therefore the `??` operator didn't catch it. Replaced with `||`