### PR TITLE
Support `probe-rs` v0.19.0 binary

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,4 +1,4 @@
-# VS Code probe-rs-debugger
+# VS Code probe-rs dap-server
 
 ## Documentation
 
@@ -31,9 +31,9 @@ Afterwards, follow the following steps:
   You can also open the "Run and Debug" panel in the left sidebar, and then
   start the "Extension" debug configuration.
 
-### To run against a compiled executable of `probe-rs-debugger`
+### To run against a compiled executable of `probe-rs`
 
-* Press `F5` to __build and launch executable__ `probe-rs-debugger`. VSCode will
+* Press `F5` to __build and launch executable__ `probe-rs`. VSCode will
   open another VS Code window, titled __[Extension Development Host]__.
 * In this new VSCode window,
   * Open an existing project, or create a new one.
@@ -41,17 +41,17 @@ Afterwards, follow the following steps:
   * Select the debug environment you just created.
     * Press `F5` to start debugging.
 
-### To run against a debuggable instance of `probe-rs-debugger`
+### To run against a debuggable instance of `probe-rs`
 
 * Clone the [probe-rs](https://github.com/probe-rs/probe-rs.git) repository, and
   open it in VSCode.
   * In this `probe-rs` repo, select the debug environment `DAP-Server
-    probe-rs-debugger`
-  * Press `F5` to start `probe-rs-debugger` as a debuggable server.
+    probe-rs`
+  * Press `F5` to start `probe-rs` as a debuggable server.
 * Switch to the VSCode instance of the probe-rs `vscode` repository.
 * In this new VSCode window,
   * Open an existing project, or create a new one.
-  * In your project, configure the `launch.json` in your project, as per [the existing debugger server](https://probe.rs/docs/tools/vscode/#using-to-an-existing-probe-rs-debugger-server) example.
+  * In your project, configure the `launch.json` in your project, as per [the standalong debugger server](https://probe.rs/docs/tools/vscode/#connecting-to-a-standalone-probe-rs-dap-server-server) example.
   * Select the debug environment you just created.
     * Press `F5` to start debugging.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-## 0.18.0 Support the new binary names for probe-rs 0.18.0
-- The probe-rs 0.18.0 release has changed the names of the binaries - [PR #1637](https://github.com/probe-rs/probe-rs/pull/1637). This release supports the new names. 
+## 0.19.0 Support the new binary names for probe-rs 0.19.0
+- The probe-rs 0.19.0 release has changed the names of the binaries - [PR #1637](https://github.com/probe-rs/probe-rs/pull/1637) and [PR #1643](https://github.com/probe-rs/probe-rs/pull/1643). This release supports the new names. 
 
 ## 0.17.0 The first stable release of the extension. 
 - The majority of the functionality is implemented in the [probe-rs-debugger](https://github.com/probe-rs/probe-rs/tree/master/debugger).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.18.0 Support the new binary names for probe-rs 0.18.0
+- The probe-rs 0.18.0 release has changed the names of the binaries - [PR #1637](https://github.com/probe-rs/probe-rs/pull/1637). This release supports the new names. 
+
 ## 0.17.0 The first stable release of the extension. 
 - The majority of the functionality is implemented in the [probe-rs-debugger](https://github.com/probe-rs/probe-rs/tree/master/debugger).
 - Please refer to the [probe-rs CHANGELOG](https://github.com/probe-rs/probe-rs/blob/master/CHANGELOG.md) for detailed information on changes that affect functionality in this extension.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "probe-rs-debugger",
     "displayName": "Debugger for probe-rs",
-    "version": "0.17.5",
+    "version": "0.18.0",
     "publisher": "probe-rs",
     "description": "probe-rs Debug Adapter for VS Code.",
     "author": {

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
                             "runtimeExecutable": {
                                 "type": "string",
                                 "description": "An OS resolvable path to the Probe-rs debugger executable.",
-                                "default": "probe-rs-debugger"
+                                "default": "probe-rs"
                             },
                             "runtimeArgs": {
                                 "type": "array",
@@ -148,8 +148,7 @@
                                 },
                                 "description": "String array of arguments to provide the startup arguments for the Probe-rs debugger executable.",
                                 "default": [
-                                    "debug",
-                                    "--dap"
+                                    "dap-server"
                                 ]
                             },
                             "env": {
@@ -322,7 +321,7 @@
                             "runtimeExecutable": {
                                 "type": "string",
                                 "description": "An OS resolvable path to the Probe-rs debugger executable.",
-                                "default": "probe-rs-debugger"
+                                "default": "probe-rs"
                             },
                             "runtimeArgs": {
                                 "type": "array",
@@ -331,8 +330,7 @@
                                 },
                                 "description": "String array of arguments to provide the startup arguments for the Probe-rs debugger executable.",
                                 "default": [
-                                    "debug",
-                                    "--dap"
+                                    "dap-server"
                                 ]
                             },
                             "env": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "probe-rs-debugger",
     "displayName": "Debugger for probe-rs",
-    "version": "0.18.0",
+    "version": "0.19.0",
     "publisher": "probe-rs",
     "description": "probe-rs Debug Adapter for VS Code.",
     "author": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -350,7 +350,7 @@ class ProbeRSDebugAdapterServerDescriptorFactory implements vscode.DebugAdapterD
             if (session.configuration.hasOwnProperty('runtimeArgs')) {
                 args = session.configuration.runtimeArgs;
             } else {
-                args = ['dap-server', 'debug'];
+                args = ['dap-server'];
             }
             args.push('--port');
             args.push(debugServer[1]);


### PR DESCRIPTION
The probe-rs 0.19.0 release has changed the names of the binaries - [PR #1637](https://github.com/probe-rs/probe-rs/pull/1637) and made additional changes to the command line options in  [PR #1643](https://github.com/probe-rs/probe-rs/pull/1643). This release supports these changes. 