### PR TITLE
Add support for non Elf binary formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,9 @@
-## 0.19.0 Support the new binary names for probe-rs 0.19.0
-- The probe-rs 0.19.0 release has changed the names of the binaries - [PR #1637](https://github.com/probe-rs/probe-rs/pull/1637) and [PR #1643](https://github.com/probe-rs/probe-rs/pull/1643). This release supports the new names. 
+## 0.19.1 Support the new binary names for probe-rs 0.19.0
+- The `probe-rs` 0.19.0 release has changed the names of the binaries - [PR #1637](https://github.com/probe-rs/probe-rs/pull/1637) and [PR #1643](https://github.com/probe-rs/probe-rs/pull/1643). This release supports the new names. 
 
 ## 0.17.0 The first stable release of the extension. 
 - The majority of the functionality is implemented in the [probe-rs-debugger](https://github.com/probe-rs/probe-rs/tree/master/debugger).
 - Please refer to the [probe-rs CHANGELOG](https://github.com/probe-rs/probe-rs/blob/master/CHANGELOG.md) for detailed information on changes that affect functionality in this extension.
-- 
 
 ## 0.4.3 An updated 'Alpha' release to update dependencies, and improve logging and stability.
 

--- a/package.json
+++ b/package.json
@@ -206,11 +206,6 @@
                                     "description": "Flash the target before debugging.",
                                     "default": true
                                 },
-                                "resetAfterFlashing": {
-                                    "type": "boolean",
-                                    "description": "Reset all cores on the target after flashing.",
-                                    "default": true
-                                },
                                 "haltAfterReset": {
                                     "type": "boolean",
                                     "description": "Halt all cores on the target after reset.",
@@ -239,7 +234,7 @@
                                                 "idf"
                                             ],
                                             "enumDescriptions": [
-                                                "The target binary file contains the contents of the flash 1:1",
+                                                "The target binary file contains the contents of the flash 1:1.",
                                                 "The target binary file conforms with the [Intel HEX](https://en.wikipedia.org/wiki/Intel_HEX) format.",
                                                 "The target binary file conforms with the [ELF](https://en.wikipedia.org/wiki/Executable_and_Linkable_Format) format.",
                                                 "The target binary file conforms with the [ESP-IDF bootloader](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/app_image_format.html#app-image-structures) format"
@@ -494,7 +489,6 @@
                         "chip": "STM32H745ZITx",
                         "flashingConfig": {
                             "flashingEnabled": true,
-                            "resetAfterFlashing": true,
                             "haltAfterReset": true
                         },
                         "coreConfigs": [
@@ -518,7 +512,6 @@
                             "chip": "STM32H745ZITx",
                             "flashingConfig": {
                                 "flashingEnabled": true,
-                                "resetAfterFlashing": true,
                                 "haltAfterReset": true
                             },
                             "coreConfigs": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "probe-rs-debugger",
     "displayName": "Debugger for probe-rs",
-    "version": "0.19.0",
+    "version": "0.19.1",
     "publisher": "probe-rs",
     "description": "probe-rs Debug Adapter for VS Code.",
     "author": {
@@ -225,6 +225,44 @@
                                     "type": "boolean",
                                     "description": "Restore erased bytes that will not be rewritten from ELF.",
                                     "default": false
+                                },
+                                "formatOptions": {
+                                    "type": "object",
+                                    "items": {
+                                        "format": {
+                                            "type": "string",
+                                            "description": "One of the supported binary formats probe-rs uses for flashing the target binary.",
+                                            "enum": [
+                                                "bin",
+                                                "hex",
+                                                "elf",
+                                                "idf"
+                                            ],
+                                            "enumDescriptions": [
+                                                "The target binary file contains the contents of the flash 1:1",
+                                                "The target binary file conforms with the [Intel HEX](https://en.wikipedia.org/wiki/Intel_HEX) format.",
+                                                "The target binary file conforms with the [ELF](https://en.wikipedia.org/wiki/Executable_and_Linkable_Format) format.",
+                                                "The target binary file conforms with the [ESP-IDF bootloader](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/app_image_format.html#app-image-structures) format"
+                                            ],
+                                            "default": "elf"
+                                        },
+                                        "baseAddress": {
+                                            "type": "number",
+                                            "description": "The address in memory where the binary will be flashed to."
+                                        },
+                                        "skip": {
+                                            "type": "number",
+                                            "description": "The number of bytes to skip at the start of the binary file."
+                                        },
+                                        "idf_bootloader": {
+                                            "type": "string",
+                                            "description": "The path (relative to `cwd` or absolute) to the ESP-IDF bootloader."
+                                        },
+                                        "idf_partion_table": {
+                                            "type": "string",
+                                            "description": "The path (relative to `cwd` or absolute) to the ESP-IDF partion table."
+                                        }
+                                    }
                                 }
                             },
                             "coreConfigs": {


### PR DESCRIPTION
In addition to the currently supported Elf format, this adds support for binary formats Bin, Hex, and Idf.

To test, please use 
- The attached [probe-rs-debugger-0.19.1.vsix.zip](https://github.com/probe-rs/vscode/files/11895442/probe-rs-debugger-0.19.1.vsix.zip)
- Companion release of the `probe-rs` dap-server `cargo install --git https://github.com/probe-rs/probe-rs --force --branch noppej/issue1647 probe-rs --features=cli`
