### PR TITLE
Ensure VSCode extension catches all STDERR errors if `probe-rs dap-server` process initialization fails.

### DIFF
--- a/dap/debugProtocol.json
+++ b/dap/debugProtocol.json
@@ -1414,7 +1414,7 @@
 		"SetExceptionBreakpointsResponse": {
 			"allOf": [ { "$ref": "#/definitions/Response" }, {
 				"type": "object",
-				"description": "Response to `setExceptionBreakpoints` request.\nThe response contains an array of `Breakpoint` objects with information about each exception breakpoint or filter. The `Breakpoint` objects are in the same order as the elements of the `filters`, `filterOptions`, `exceptionOptions` arrays given as arguments. If both `filters` and `filterOptions` are given, the returned array must start with `filters` information first, followed by `filterOptions` information.\nThe `verified` property of a `Breakpoint` object signals whether the exception breakpoint or filter could be successfully created and whether the condition or hit count expressions are valid. In case of an error the `message` property explains the problem. The `id` property can be used to introduce a unique ID for the exception breakpoint or filter so that it can be updated subsequently by sending breakpoint events.\nFor backward compatibility both the `breakpoints` array and the enclosing `body` are optional. If these elements are missing a client is not able to show problems for individual exception breakpoints or filters.",
+				"description": "Response to `setExceptionBreakpoints` request.\nThe response contains an array of `Breakpoint` objects with information about each exception breakpoint or filter. The `Breakpoint` objects are in the same order as the elements of the `filters`, `filterOptions`, `exceptionOptions` arrays given as arguments. If both `filters` and `filterOptions` are given, the returned array must start with `filters` information first, followed by `filterOptions` information.\nThe `verified` property of a `Breakpoint` object signals whether the exception breakpoint or filter could be successfully created and whether the condition is valid. In case of an error the `message` property explains the problem. The `id` property can be used to introduce a unique ID for the exception breakpoint or filter so that it can be updated subsequently by sending breakpoint events.\nFor backward compatibility both the `breakpoints` array and the enclosing `body` are optional. If these elements are missing a client is not able to show problems for individual exception breakpoints or filters.",
 				"properties": {
 					"body": {
 						"type": "object",
@@ -1477,7 +1477,7 @@
 						"properties": {
 							"dataId": {
 								"type": [ "string", "null" ],
-								"description": "An identifier for the data on which a data breakpoint can be registered with the `setDataBreakpoints` request or null if no data breakpoint is available."
+								"description": "An identifier for the data on which a data breakpoint can be registered with the `setDataBreakpoints` request or null if no data breakpoint is available. If a `variablesReference` or `frameId` is passed, the `dataId` is valid in the current suspended state, otherwise it's valid indefinitely. See 'Lifetime of Object References' in the Overview section for details. Breakpoints set using the `dataId` in the `setDataBreakpoints` request may outlive the lifetime of the associated `dataId`."
 							},
 							"description": {
 								"type": "string",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "probe-rs-debugger",
     "displayName": "Debugger for probe-rs",
-    "version": "0.19.1",
+    "version": "0.20.0",
     "publisher": "probe-rs",
     "description": "probe-rs Debug Adapter for VS Code.",
     "author": {
@@ -23,7 +23,7 @@
         "SVD"
     ],
     "engines": {
-        "vscode": ">=1.78.0"
+        "vscode": ">=1.80.0"
     },
     "icon": "images/probe-rs-debugger.png",
     "categories": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -399,10 +399,15 @@ class ProbeRSDebugAdapterServerDescriptorFactory implements vscode.DebugAdapterD
 
             // Capture stderr to ensure OS and RUST_LOG error messages can be brought to the user's attention.
             launchedDebugAdapter.stderr?.on('data', (data: string) => {
-                if (debuggerStatus === (DebuggerStatus.running as DebuggerStatus)) {
+                if (
+                    debuggerStatus === (DebuggerStatus.running as DebuggerStatus) ||
+                    data.toString().startsWith(ConsoleLogSources.console)
+                ) {
                     logToConsole(data.toString(), true);
                 } else {
-                    // Any STDERR messages during startup, or on process error, need special consideration, otherwise they will be lost.
+                    // Any STDERR messages during startup, or on process error, that
+                    // are not DebuggerStatus.console types, need special consideration,
+                    // otherwise they will be lost.
                     debuggerStatus = DebuggerStatus.failed;
                     logToConsole(
                         `${JSON.stringify(ConsoleLogSources.error)}: ${JSON.stringify(


### PR DESCRIPTION
Currently, the VSCode extension will report Node `child_process.spawn()` error messages when the `probe-rs dap-server` process initialization fails, and "unintentionally" looses the STDERR messages which accompany this event. 

This PR will ensure the STDERR messages are shown to the user, to help them fix configuration related errors.

In addition, this PR also:
- Updates the MS DAP Protocol specification to 1.62.0.
- Bumps the extension version number to 0.20.0

Note: Ideally we should wait for https://github.com/probe-rs/probe-rs/pull/1699 to be released before merging this PR.
