### PR TITLE
Fix launch config intellisense

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "probe-rs-debugger",
     "displayName": "Debugger for probe-rs",
-    "version": "0.21.3",
+    "version": "0.21.4",
     "publisher": "probe-rs",
     "description": "probe-rs Debug Adapter for VS Code.",
     "author": {
@@ -201,61 +201,63 @@
                             "flashingConfig": {
                                 "type": "object",
                                 "description": "These options are applied when flashing one or more `program_binary` files to the target memory.",
-                                "flashingEnabled": {
-                                    "type": "boolean",
-                                    "description": "Flash the target before debugging.",
-                                    "default": true
-                                },
-                                "haltAfterReset": {
-                                    "type": "boolean",
-                                    "description": "Halt all cores on the target after reset.",
-                                    "default": true
-                                },
-                                "fullChipErase": {
-                                    "type": "boolean",
-                                    "description": "Do a full chip erase, versus page-by-page erase.",
-                                    "default": false
-                                },
-                                "restoreUnwrittenBytes": {
-                                    "type": "boolean",
-                                    "description": "Restore erased bytes that will not be rewritten from ELF.",
-                                    "default": false
-                                },
-                                "formatOptions": {
-                                    "type": "object",
-                                    "items": {
-                                        "format": {
-                                            "type": "string",
-                                            "description": "One of the supported binary formats probe-rs uses for flashing the target binary.",
-                                            "enum": [
-                                                "bin",
-                                                "hex",
-                                                "elf",
-                                                "idf"
-                                            ],
-                                            "enumDescriptions": [
-                                                "The target binary file contains the verbatim contents of the flash.",
-                                                "The target binary file conforms with the [Intel HEX](https://en.wikipedia.org/wiki/Intel_HEX) format.",
-                                                "The target binary file conforms with the [ELF](https://en.wikipedia.org/wiki/Executable_and_Linkable_Format) format.",
-                                                "The target binary file conforms with the [ESP-IDF bootloader](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/app_image_format.html#app-image-structures) format"
-                                            ],
-                                            "default": "elf"
-                                        },
-                                        "baseAddress": {
-                                            "type": "number",
-                                            "description": "The address in memory where the binary will be flashed to."
-                                        },
-                                        "skip": {
-                                            "type": "number",
-                                            "description": "The number of bytes to skip at the start of the binary file."
-                                        },
-                                        "idf_bootloader": {
-                                            "type": "string",
-                                            "description": "The path (relative to `cwd` or absolute) to the ESP-IDF bootloader."
-                                        },
-                                        "idf_partition_table": {
-                                            "type": "string",
-                                            "description": "The path (relative to `cwd` or absolute) to the ESP-IDF partition table."
+                                "properties": {
+                                    "flashingEnabled": {
+                                        "type": "boolean",
+                                        "description": "Flash the target before debugging.",
+                                        "default": true
+                                    },
+                                    "haltAfterReset": {
+                                        "type": "boolean",
+                                        "description": "Halt all cores on the target after reset.",
+                                        "default": true
+                                    },
+                                    "fullChipErase": {
+                                        "type": "boolean",
+                                        "description": "Do a full chip erase, versus page-by-page erase.",
+                                        "default": false
+                                    },
+                                    "restoreUnwrittenBytes": {
+                                        "type": "boolean",
+                                        "description": "Restore erased bytes that will not be rewritten from ELF.",
+                                        "default": false
+                                    },
+                                    "formatOptions": {
+                                        "type": "object",
+                                        "properties": {
+                                            "format": {
+                                                "type": "string",
+                                                "description": "One of the supported binary formats probe-rs uses for flashing the target binary.",
+                                                "enum": [
+                                                    "bin",
+                                                    "hex",
+                                                    "elf",
+                                                    "idf"
+                                                ],
+                                                "enumDescriptions": [
+                                                    "The target binary file contains the verbatim contents of the flash.",
+                                                    "The target binary file conforms with the [Intel HEX](https://en.wikipedia.org/wiki/Intel_HEX) format.",
+                                                    "The target binary file conforms with the [ELF](https://en.wikipedia.org/wiki/Executable_and_Linkable_Format) format.",
+                                                    "The target binary file conforms with the [ESP-IDF bootloader](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/app_image_format.html#app-image-structures) format"
+                                                ],
+                                                "default": "elf"
+                                            },
+                                            "baseAddress": {
+                                                "type": "number",
+                                                "description": "The address in memory where the binary will be flashed to."
+                                            },
+                                            "skip": {
+                                                "type": "number",
+                                                "description": "The number of bytes to skip at the start of the binary file."
+                                            },
+                                            "idf_bootloader": {
+                                                "type": "string",
+                                                "description": "The path (relative to `cwd` or absolute) to the ESP-IDF bootloader."
+                                            },
+                                            "idf_partition_table": {
+                                                "type": "string",
+                                                "description": "The path (relative to `cwd` or absolute) to the ESP-IDF partition table."
+                                            }
                                         }
                                     }
                                 }
@@ -264,60 +266,66 @@
                                 "type": "array",
                                 "description": "Each MCU core will have a mandatory `coreIndex`, `programBinary`, and `chip` as well as several other optional properties.",
                                 "items": {
+                                    "type": "object",
                                     "required": [
                                         "programBinary"
                                     ],
-                                    "coreIndex": {
-                                        "type": "number",
-                                        "description": "The zero based index of the MCU core for this session",
-                                        "default": 0
-                                    },
-                                    "programBinary": {
-                                        "type": "string",
-                                        "description": "The path (relative to `cwd` or absolute) to the binary for your target firmware",
-                                        "default": "./target/thumbv7em-none-eabihf/debug/${workspaceFolderBasename}"
-                                    },
-                                    "svdFile": {
-                                        "type": "string",
-                                        "description": "The path (relative to `cwd` or absolute) to the CMCIS-SVD file for your target core",
-                                        "default": "./CMSIS.SVD"
-                                    },
-                                    "rttEnabled": {
-                                        "type": "boolean",
-                                        "description": "If true, the debugger will open an RTT Terminal tab for each of the active channels on the target.",
-                                        "default": false
-                                    },
-                                    "rttChannelFormats": {
-                                        "type": "array",
-                                        "items": {
-                                            "channelNumber": {
-                                                "type": "number",
-                                                "description": "The channel number to which this data format applies. If any active channel numbers are omitted, we will assume the default will be `dataFormat=String', and 'showTimestamps=false'."
-                                            },
-                                            "dataFormat": {
-                                                "type": "string",
-                                                "description": "One of the supported data formats for RTT channels.",
-                                                "enum": [
-                                                    "String",
-                                                    "BinaryLE",
-                                                    "Defmt"
-                                                ],
-                                                "enumDescriptions": [
-                                                    "String (text) format.",
-                                                    "Binary Little Endian format.",
-                                                    "Deferred formatting (see: https://defmt.ferrous-systems.com)."
-                                                ],
-                                                "default": "String"
-                                            },
-                                            "showTimestamps": {
-                                                "type": "boolean",
-                                                "default": false,
-                                                "description": "Enable the inclusion of timestamps in the RTT output for `dataFormat=String`."
-                                            },
-                                            "showLocation": {
-                                                "type": "boolean",
-                                                "default": true,
-                                                "description": "Enable the inclusion of Defmt location information in the RTT output for `dataFormat=Defmt`."
+                                    "properties": {
+                                        "coreIndex": {
+                                            "type": "number",
+                                            "description": "The zero based index of the MCU core for this session",
+                                            "default": 0
+                                        },
+                                        "programBinary": {
+                                            "type": "string",
+                                            "description": "The path (relative to `cwd` or absolute) to the binary for your target firmware",
+                                            "default": "./target/thumbv7em-none-eabihf/debug/${workspaceFolderBasename}"
+                                        },
+                                        "svdFile": {
+                                            "type": "string",
+                                            "description": "The path (relative to `cwd` or absolute) to the CMCIS-SVD file for your target core",
+                                            "default": "./CMSIS.SVD"
+                                        },
+                                        "rttEnabled": {
+                                            "type": "boolean",
+                                            "description": "If true, the debugger will open an RTT Terminal tab for each of the active channels on the target.",
+                                            "default": false
+                                        },
+                                        "rttChannelFormats": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "channelNumber": {
+                                                        "type": "number",
+                                                        "description": "The channel number to which this data format applies. If any active channel numbers are omitted, we will assume the default will be `dataFormat=String', and 'showTimestamps=false'."
+                                                    },
+                                                    "dataFormat": {
+                                                        "type": "string",
+                                                        "description": "One of the supported data formats for RTT channels.",
+                                                        "enum": [
+                                                            "String",
+                                                            "BinaryLE",
+                                                            "Defmt"
+                                                        ],
+                                                        "enumDescriptions": [
+                                                            "String (text) format.",
+                                                            "Binary Little Endian format.",
+                                                            "Deferred formatting (see: https://defmt.ferrous-systems.com)."
+                                                        ],
+                                                        "default": "String"
+                                                    },
+                                                    "showTimestamps": {
+                                                        "type": "boolean",
+                                                        "default": false,
+                                                        "description": "Enable the inclusion of timestamps in the RTT output for `dataFormat=String`."
+                                                    },
+                                                    "showLocation": {
+                                                        "type": "boolean",
+                                                        "default": true,
+                                                        "description": "Enable the inclusion of Defmt location information in the RTT output for `dataFormat=Defmt`."
+                                                    }
+                                                }
                                             }
                                         }
                                     }
@@ -417,60 +425,66 @@
                                 "type": "array",
                                 "description": "Each MCU core will have a mandatory `coreIndex`, `programBinary`, and `chip` as well as several other optional properties.",
                                 "items": {
-                                    "required": [
-                                        "programBinary"
-                                    ],
-                                    "coreIndex": {
-                                        "type": "number",
-                                        "description": "The zero based index of the MCU core for this session",
-                                        "default": 0
-                                    },
-                                    "programBinary": {
-                                        "type": "string",
-                                        "description": "The path (relative to `cwd` or absolute) to the binary for your target firmware",
-                                        "default": "./target/thumbv7em-none-eabihf/debug/${workspaceFolderBasename}"
-                                    },
-                                    "svdFile": {
-                                        "type": "string",
-                                        "description": "The path (relative to `cwd` or absolute) to the CMCIS-SVD file for your target core",
-                                        "default": "./CMSIS.SVD"
-                                    },
-                                    "rttEnabled": {
-                                        "type": "boolean",
-                                        "description": "If true, the debugger will open an RTT Terminal tab for each of the active channels on the target.",
-                                        "default": false
-                                    },
-                                    "rttChannelFormats": {
-                                        "type": "array",
-                                        "items": {
-                                            "channelNumber": {
-                                                "type": "number",
-                                                "description": "The channel number to which this data format applies. If any active channel numbers are omitted, we will assume the default will be `dataFormat=String', and 'showTimestamps=false'."
-                                            },
-                                            "dataFormat": {
-                                                "type": "string",
-                                                "description": "One of the supported data formats for RTT channels.",
-                                                "enum": [
-                                                    "String",
-                                                    "BinaryLE",
-                                                    "Defmt"
-                                                ],
-                                                "enumDescriptions": [
-                                                    "String (text) format.",
-                                                    "Binary Little Endian format.",
-                                                    "Deferred formatting (see: https://defmt.ferrous-systems.com)."
-                                                ],
-                                                "default": "String"
-                                            },
-                                            "showTimestamps": {
-                                                "type": "boolean",
-                                                "default": false,
-                                                "description": "Enable the inclusion of timestamps in the RTT output for `dataFormat=String`."
-                                            },
-                                            "showLocation": {
-                                                "type": "boolean",
-                                                "default": true,
-                                                "description": "Enable the inclusion of Defmt location information in the RTT output for `dataFormat=Defmt`."
+                                    "type": "object",
+                                    "properties": {
+                                        "required": [
+                                            "programBinary"
+                                        ],
+                                        "coreIndex": {
+                                            "type": "number",
+                                            "description": "The zero based index of the MCU core for this session",
+                                            "default": 0
+                                        },
+                                        "programBinary": {
+                                            "type": "string",
+                                            "description": "The path (relative to `cwd` or absolute) to the binary for your target firmware",
+                                            "default": "./target/thumbv7em-none-eabihf/debug/${workspaceFolderBasename}"
+                                        },
+                                        "svdFile": {
+                                            "type": "string",
+                                            "description": "The path (relative to `cwd` or absolute) to the CMCIS-SVD file for your target core",
+                                            "default": "./CMSIS.SVD"
+                                        },
+                                        "rttEnabled": {
+                                            "type": "boolean",
+                                            "description": "If true, the debugger will open an RTT Terminal tab for each of the active channels on the target.",
+                                            "default": false
+                                        },
+                                        "rttChannelFormats": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "channelNumber": {
+                                                        "type": "number",
+                                                        "description": "The channel number to which this data format applies. If any active channel numbers are omitted, we will assume the default will be `dataFormat=String', and 'showTimestamps=false'."
+                                                    },
+                                                    "dataFormat": {
+                                                        "type": "string",
+                                                        "description": "One of the supported data formats for RTT channels.",
+                                                        "enum": [
+                                                            "String",
+                                                            "BinaryLE",
+                                                            "Defmt"
+                                                        ],
+                                                        "enumDescriptions": [
+                                                            "String (text) format.",
+                                                            "Binary Little Endian format.",
+                                                            "Deferred formatting (see: https://defmt.ferrous-systems.com)."
+                                                        ],
+                                                        "default": "String"
+                                                    },
+                                                    "showTimestamps": {
+                                                        "type": "boolean",
+                                                        "default": false,
+                                                        "description": "Enable the inclusion of timestamps in the RTT output for `dataFormat=String`."
+                                                    },
+                                                    "showLocation": {
+                                                        "type": "boolean",
+                                                        "default": true,
+                                                        "description": "Enable the inclusion of Defmt location information in the RTT output for `dataFormat=Defmt`."
+                                                    }
+                                                }
                                             }
                                         }
                                     }


### PR DESCRIPTION
It looks like the extension's `contributes` contents aren't validated. An object's fields should be listed under `properties`. Array items don't default to `object` type, so I've fixed them, too.

Not sure if this is a regression, but the extension UX should now be a lot better around editing launch.json. Hopefully I didn't miss any places :)