### PR TITLE
Update publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,4 @@ jobs:
       - run: npm install -g vsce
       - run: npm run pretest
       - name: Finally, publish to the marketplace.
-        run: npm run publish
-        env:
-          VSCE_PAT: ${{ secrets.VS_MARKETPLACE_TOKEN }}
+        run: npm run publish --pat ${{ secrets.VS_MARKETPLACE_TOKEN }}


### PR DESCRIPTION
Pass PAT to `vsce publish` as an alternative to relying on the `env:`

Note: It is not clear why the previous approach stopped working, and am hoping the more direct approach will succeed.