### PR TITLE
Fix debuggerExecutable being ignored

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "probe-rs-debugger",
     "displayName": "Debugger for probe-rs",
-    "version": "0.22.1",
+    "version": "0.22.2",
     "publisher": "probe-rs",
     "description": "probe-rs Debug Adapter for VS Code.",
     "author": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -534,7 +534,7 @@ function startDebugServer(
 // This takes the value from configuration, if set, or
 // falls back to the default name.
 function debuggerExecutablePath(): string {
-    let configuration = vscode.workspace.getConfiguration('probe-rs');
+    let configuration = vscode.workspace.getConfiguration('probe-rs-debugger');
 
     let configuredPath: string = configuration.get('debuggerExecutable') || defaultExecutable();
 


### PR DESCRIPTION
We ran into an issue where the extension config was ignored. I believe the problem is an incorrect secion ID, which this PR updates.