### PR TITLE
Fix RTT terminal creation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -197,7 +197,7 @@ class ProbeRSDebugAdapterServerDescriptorFactory implements vscode.DebugAdapterD
                     name: channelName,
                     pty: channelPty,
                 };
-                for (let index in this.rttTerminals) {
+                for (let index = 0; index < this.rttTerminals.length; index++) {
                     var [formerChannelNumber, , ,] = this.rttTerminals[index];
                     if (formerChannelNumber === channelNumber) {
                         this.rttTerminals.splice(+index, 1);


### PR DESCRIPTION
Currently RTT terminals won't be created even when RTT is configured correctly. This patch fix the problem.