### PR TITLE
Add new/missing defmt log format options

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,5 +11,8 @@
     // Enable prettier format on save
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true,
-    "editor.formatOnPaste": false
+    "editor.formatOnPaste": false,
+    "[json]": {
+        "editor.defaultFormatter": "vscode.json-language-features"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -107,9 +107,10 @@
         "debuggers": [
             {
                 "type": "probe-rs-debug",
-                "label": "Debug adapter on top of probe-rs",
+                "label": "probe-rs Debugger",
                 "languages": [
-                    "rust"
+                    "rust",
+                    "c"
                 ],
                 "configurationAttributes": {
                     "launch": {

--- a/package.json
+++ b/package.json
@@ -296,7 +296,7 @@
                                         },
                                         "svdFile": {
                                             "type": "string",
-                                            "description": "The path (relative to `cwd` or absolute) to the CMCIS-SVD file for your target core"
+                                            "description": "The path (relative to `cwd` or absolute) to the CMSIS-SVD file for your target core"
                                         },
                                         "rttEnabled": {
                                             "type": "boolean",
@@ -327,7 +327,7 @@
                                                         "enumDescriptions": [
                                                             "String (text) format.",
                                                             "Binary Little Endian format.",
-                                                            "Deferred formatting (see: https://defmt.ferrous-systems.com)."
+                                                            "defmt (see: https://defmt.ferrous-systems.com)."
                                                         ],
                                                         "default": "String"
                                                     },
@@ -351,7 +351,7 @@
                                                     },
                                                     "showLocation": {
                                                         "type": "boolean",
-                                                        "description": "Enable the inclusion of Defmt location information in the RTT output for `dataFormat=Defmt`."
+                                                        "description": "Enable the inclusion of defmt location information in the RTT output for `dataFormat=Defmt`."
                                                     },
                                                     "defmtLogFormat": {
                                                         "type": "string",
@@ -485,7 +485,7 @@
                                         },
                                         "svdFile": {
                                             "type": "string",
-                                            "description": "The path (relative to `cwd` or absolute) to the CMCIS-SVD file for your target core"
+                                            "description": "The path (relative to `cwd` or absolute) to the CMSIS-SVD file for your target core"
                                         },
                                         "rttEnabled": {
                                             "type": "boolean",
@@ -516,7 +516,7 @@
                                                         "enumDescriptions": [
                                                             "String (text) format.",
                                                             "Binary Little Endian format.",
-                                                            "Deferred formatting (see: https://defmt.ferrous-systems.com)."
+                                                            "defmt (see: https://defmt.ferrous-systems.com)."
                                                         ],
                                                         "default": "String"
                                                     },
@@ -540,7 +540,7 @@
                                                     },
                                                     "showLocation": {
                                                         "type": "boolean",
-                                                        "description": "Enable the inclusion of Defmt location information in the RTT output for `dataFormat=Defmt`."
+                                                        "description": "Enable the inclusion of defmt location information in the RTT output for `dataFormat=Defmt`."
                                                     },
                                                     "defmtLogFormat": {
                                                         "type": "string",

--- a/package.json
+++ b/package.json
@@ -327,6 +327,20 @@
                                                         ],
                                                         "default": "String"
                                                     },
+                                                    "mode": {
+                                                        "type": "string",
+                                                        "description": "RTT operating mode.",
+                                                        "enum": [
+                                                            "NoBlockSkip",
+                                                            "NoBlockTrim",
+                                                            "BlockIfFull"
+                                                        ],
+                                                        "enumDescriptions": [
+                                                            "The target will add data to the channel only if it fits completely, otherwise it will skip the data.",
+                                                            "The target will add as much data to the channel as possible, without blocking.",
+                                                            "The target will block until there is enough space in the channel to add the data."
+                                                        ]
+                                                    },
                                                     "showTimestamps": {
                                                         "type": "boolean",
                                                         "default": false,
@@ -336,6 +350,10 @@
                                                         "type": "boolean",
                                                         "default": true,
                                                         "description": "Enable the inclusion of Defmt location information in the RTT output for `dataFormat=Defmt`."
+                                                    },
+                                                    "defmtLogFormat": {
+                                                        "type": "string",
+                                                        "description": "The default format string to use for decoding defmt logs."
                                                     }
                                                 }
                                             }
@@ -496,6 +514,20 @@
                                                         ],
                                                         "default": "String"
                                                     },
+                                                    "mode": {
+                                                        "type": "string",
+                                                        "description": "RTT operating mode.",
+                                                        "enum": [
+                                                            "NoBlockSkip",
+                                                            "NoBlockTrim",
+                                                            "BlockIfFull"
+                                                        ],
+                                                        "enumDescriptions": [
+                                                            "The target will add data to the channel only if it fits completely, otherwise it will skip the data.",
+                                                            "The target will add as much data to the channel as possible, without blocking.",
+                                                            "The target will block until there is enough space in the channel to add the data."
+                                                        ]
+                                                    },
                                                     "showTimestamps": {
                                                         "type": "boolean",
                                                         "default": false,
@@ -505,6 +537,10 @@
                                                         "type": "boolean",
                                                         "default": true,
                                                         "description": "Enable the inclusion of Defmt location information in the RTT output for `dataFormat=Defmt`."
+                                                    },
+                                                    "defmtLogFormat": {
+                                                        "type": "string",
+                                                        "description": "The default format string to use for decoding defmt logs."
                                                     }
                                                 }
                                             }

--- a/package.json
+++ b/package.json
@@ -305,12 +305,16 @@
                                         },
                                         "rttChannelFormats": {
                                             "type": "array",
+                                            "description": "RTT channel configuration. Unlisted active channels will be configured with `dataFormat=String', and 'showTimestamps=true'.",
                                             "items": {
                                                 "type": "object",
+                                                "required": [
+                                                    "channelNumber"
+                                                ],
                                                 "properties": {
                                                     "channelNumber": {
                                                         "type": "number",
-                                                        "description": "The channel number to which this data format applies. If any active channel numbers are omitted, we will assume the default will be `dataFormat=String', and 'showTimestamps=false'."
+                                                        "description": "The channel number to which this data format applies."
                                                     },
                                                     "dataFormat": {
                                                         "type": "string",
@@ -343,12 +347,10 @@
                                                     },
                                                     "showTimestamps": {
                                                         "type": "boolean",
-                                                        "default": false,
                                                         "description": "Enable the inclusion of timestamps in the RTT output for `dataFormat=String`."
                                                     },
                                                     "showLocation": {
                                                         "type": "boolean",
-                                                        "default": true,
                                                         "description": "Enable the inclusion of Defmt location information in the RTT output for `dataFormat=Defmt`."
                                                     },
                                                     "defmtLogFormat": {
@@ -492,12 +494,16 @@
                                         },
                                         "rttChannelFormats": {
                                             "type": "array",
+                                            "description": "RTT channel configuration. Unlisted active channels will be configured with `dataFormat=String', and 'showTimestamps=true'.",
                                             "items": {
                                                 "type": "object",
+                                                "required": [
+                                                    "channelNumber"
+                                                ],
                                                 "properties": {
                                                     "channelNumber": {
                                                         "type": "number",
-                                                        "description": "The channel number to which this data format applies. If any active channel numbers are omitted, we will assume the default will be `dataFormat=String', and 'showTimestamps=false'."
+                                                        "description": "The channel number to which this data format applies."
                                                     },
                                                     "dataFormat": {
                                                         "type": "string",
@@ -530,12 +536,10 @@
                                                     },
                                                     "showTimestamps": {
                                                         "type": "boolean",
-                                                        "default": false,
                                                         "description": "Enable the inclusion of timestamps in the RTT output for `dataFormat=String`."
                                                     },
                                                     "showLocation": {
                                                         "type": "boolean",
-                                                        "default": true,
                                                         "description": "Enable the inclusion of Defmt location information in the RTT output for `dataFormat=Defmt`."
                                                     },
                                                     "defmtLogFormat": {

--- a/package.json
+++ b/package.json
@@ -353,7 +353,7 @@
                                                         "type": "boolean",
                                                         "description": "Enable the inclusion of defmt location information in the RTT output for `dataFormat=Defmt`."
                                                     },
-                                                    "defmtLogFormat": {
+                                                    "logFormat": {
                                                         "type": "string",
                                                         "description": "The default format string to use for decoding defmt logs."
                                                     }
@@ -542,7 +542,7 @@
                                                         "type": "boolean",
                                                         "description": "Enable the inclusion of defmt location information in the RTT output for `dataFormat=Defmt`."
                                                     },
-                                                    "defmtLogFormat": {
+                                                    "logFormat": {
                                                         "type": "string",
                                                         "description": "The default format string to use for decoding defmt logs."
                                                     }

--- a/package.json
+++ b/package.json
@@ -215,6 +215,7 @@
                             },
                             "flashingConfig": {
                                 "type": "object",
+                                "additionalProperties": false,
                                 "description": "These options are applied when flashing one or more `program_binary` files to the target memory.",
                                 "properties": {
                                     "flashingEnabled": {
@@ -239,6 +240,7 @@
                                     },
                                     "formatOptions": {
                                         "type": "object",
+                                        "additionalProperties": false,
                                         "properties": {
                                             "format": {
                                                 "type": "string",
@@ -282,6 +284,7 @@
                                 "description": "Each MCU core has a mandatory `programBinary` as well as several other optional properties.",
                                 "items": {
                                     "type": "object",
+                                    "additionalProperties": false,
                                     "required": [
                                         "programBinary"
                                     ],
@@ -471,6 +474,7 @@
                                 "description": "Each MCU core has a mandatory `programBinary` as well as several other optional properties.",
                                 "items": {
                                     "type": "object",
+                                    "additionalProperties": false,
                                     "properties": {
                                         "required": [
                                             "programBinary"
@@ -498,6 +502,7 @@
                                             "description": "RTT channel configuration. Unlisted active channels will be configured with `dataFormat=String', and 'showTimestamps=true'.",
                                             "items": {
                                                 "type": "object",
+                                                "additionalProperties": false,
                                                 "required": [
                                                     "channelNumber"
                                                 ],


### PR DESCRIPTION
Source is https://github.com/probe-rs/probe-rs/blob/08cc1456dd54e8df7a7afe34b0ba0f8345506752/probe-rs/src/bin/probe-rs/util/rtt.rs#L124-L145

This PR depends on a 0.24 release